### PR TITLE
Highlight active project states on coverage map

### DIFF
--- a/components/CoverageMap.jsx
+++ b/components/CoverageMap.jsx
@@ -1,20 +1,25 @@
 "use client";
-import { ComposableMap, Geographies, Geography, Marker } from "react-simple-maps";
+import { ComposableMap, Geographies, Geography } from "react-simple-maps";
 
-const locations = [
-  { name: "Monterrey, NL", coordinates: [-100.3161, 25.6866] },
-  { name: "Campeche, Camp.", coordinates: [-90.5349, 19.8301] },
-  { name: "Mérida, Yuc.", coordinates: [-89.5926, 20.9674] },
+const activeStates = [
+  "Campeche",
+  "Yucatán",
+  "Nuevo León",
+  "Tlaxcala",
+  "Querétaro",
+  "Jalisco",
+  "Ciudad de México",
+  "Puebla",
 ];
 
 export default function CoverageMap() {
   return (
-    <section className="mx-auto max-w-14xl px-4 py-16">
-      <h3 className="text-center text-2xl md:text-3xl font-bold text-custom-orange dark:text-custom-orange-light mb-4">
-        Nuestra cobertura presencial en México
+    <section className="mx-auto max-w-14xl px-4 py-8">
+      <h3 className="text-center text-2xl md:text-3xl font-bold text-custom-orange dark:text-custom-orange-light mb-2">
+        Estados con proyectos activos
       </h3>
-      <p className="text-center text-stone-600 dark:text-stone-400 mb-8">
-        Presencia de servicio en México.
+      <p className="text-center text-stone-600 dark:text-stone-400 mb-4">
+        Ubicaciones donde actualmente trabajamos.
       </p>
       <div className="flex justify-center">
         <ComposableMap
@@ -22,47 +27,27 @@ export default function CoverageMap() {
           projectionConfig={{ scale: 1000, center: [-102, 24] }}
           width={800}
           height={600}
-          aria-label="Mapa de México con cobertura nacional"
+          aria-label="Mapa de México con proyectos activos"
+          style={{ width: "100%", height: "auto" }}
         >
           <Geographies geography="/mexico.json">
             {({ geographies }) =>
-              geographies.map((geo) => (
-                <g key={geo.rsmKey}>
-                  {/* Base map for light and dark modes */}
+              geographies.map((geo) => {
+                const isActive = activeStates.includes(geo.properties.name);
+                return (
                   <Geography
+                    key={geo.rsmKey}
                     geography={geo}
-                    className="fill-stone-200 dark:fill-stone-700 stroke-stone-400 dark:stroke-stone-500 hover:fill-custom-orange/60 transition-colors"
+                    className={`${
+                      isActive
+                        ? "fill-custom-orange dark:fill-custom-orange-light"
+                        : "fill-white dark:fill-white"
+                    } stroke-stone-400 dark:stroke-stone-500`}
                   />
-                  {/* Coverage overlay */}
-                  <Geography
-                    geography={geo}
-                    className="fill-custom-orange dark:fill-custom-orange-light opacity-20 pointer-events-none"
-                  />
-                </g>
-              ))
+                );
+              })
             }
           </Geographies>
-          {locations.map(({ name, coordinates }) => (
-            <Marker key={name} coordinates={coordinates}>
-              <g aria-label={name} tabIndex={0}>
-                <circle
-                  r={8}
-                  className="animate-ping fill-custom-orange/70 dark:fill-custom-orange-light/70"
-                />
-                <circle
-                  r={5}
-                  className="fill-custom-orange dark:fill-custom-orange-light stroke-white dark:stroke-stone-900 stroke-2"
-                />
-              </g>
-              <text
-                textAnchor="middle"
-                y={-10}
-                className="text-xs font-medium text-stone-900 dark:text-stone-100 drop-shadow-[0_1px_1px_rgba(0,0,0,0.7)]"
-              >
-                {name}
-              </text>
-            </Marker>
-          ))}
         </ComposableMap>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Color only states with active projects on the Mexico map
- Remove city markers and update heading/spacing for a cleaner layout
- Make map responsive with white base in light and dark themes

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689787ebd714832aa5272bc5919ad9a6