### PR TITLE
feat: show state name popup on map

### DIFF
--- a/components/CoverageMap.jsx
+++ b/components/CoverageMap.jsx
@@ -1,4 +1,5 @@
 "use client";
+import { useState } from "react";
 import { ComposableMap, Geographies, Geography } from "react-simple-maps";
 
 const activeStates = [
@@ -13,6 +14,21 @@ const activeStates = [
 ];
 
 export default function CoverageMap() {
+  const [selectedState, setSelectedState] = useState(null);
+  const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
+
+  const handleClick = (geo, event) => {
+    const name = geo.properties.name;
+    if (activeStates.includes(name)) {
+      const svg = event.currentTarget.ownerSVGElement;
+      const rect = svg.getBoundingClientRect();
+      setTooltipPos({ x: event.clientX - rect.left, y: event.clientY - rect.top });
+      setSelectedState(name);
+    } else {
+      setSelectedState(null);
+    }
+  };
+
   return (
     <section className="mx-auto max-w-14xl px-4 py-8">
       <h3 className="text-center text-2xl md:text-3xl font-bold text-custom-orange dark:text-custom-orange-light mb-2">
@@ -21,7 +37,7 @@ export default function CoverageMap() {
       <p className="text-center text-stone-600 dark:text-stone-400 mb-4">
         Ubicaciones donde actualmente trabajamos.
       </p>
-      <div className="flex justify-center">
+      <div className="relative flex justify-center">
         <ComposableMap
           projection="geoMercator"
           projectionConfig={{ scale: 1000, center: [-102, 24] }}
@@ -38,6 +54,13 @@ export default function CoverageMap() {
                   <Geography
                     key={geo.rsmKey}
                     geography={geo}
+                    onClick={(e) => handleClick(geo, e)}
+                    tabIndex={-1}
+                    style={{
+                      default: { outline: "none" },
+                      hover: { outline: "none" },
+                      pressed: { outline: "none" },
+                    }}
                     className={`${
                       isActive
                         ? "fill-custom-orange dark:fill-custom-orange-light"
@@ -49,6 +72,14 @@ export default function CoverageMap() {
             }
           </Geographies>
         </ComposableMap>
+        {selectedState && (
+          <div
+            className="absolute bg-white text-black dark:bg-stone-800 dark:text-white px-3 py-1 rounded shadow-md"
+            style={{ top: tooltipPos.y, left: tooltipPos.x, transform: "translate(-50%, -110%)" }}
+          >
+            {selectedState}
+          </div>
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- replace default selection border on coverage map with custom popup showing state name

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(requires configuration: https://nextjs.org/docs/basic-features/eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68978a58b4f4832a9224431bb866d950